### PR TITLE
Module names

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,4 +9,5 @@
     '@babel',
   ],
   extends: ['standard'],
+  ignorePatterns: ['dist']
 }

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ A minimal UI to build `package.json` files for Fastify projects. Built with [fas
 <img width="1328" alt="Screen Shot 2022-01-30 at 08 53 24" src="https://user-images.githubusercontent.com/12291/151698515-a2cb977c-cd43-4fa6-bdbe-b5137746065c.png">
 
 All data comes from `plugins.mjs`.
+
+If you change/add/remove a package in the `plugins.mjs` file, you need to run `npm run generate`. This updates `data.json` with updated plugin information.

--- a/data.json
+++ b/data.json
@@ -7,10 +7,10 @@
       "homepage": "https://github.com/smartiniOnGitHub/fastify-healthcheck#readme"
     },
     {
-      "name": "under-pressure",
-      "description": "`under-pressure@6.1.0` has been deprecated. Please use `@fastify/under-pressure@7.0.0` instead.",
-      "version": "6.1.0",
-      "homepage": "https://github.com/fastify/under-pressure"
+      "name": "@fastify/under-pressure",
+      "description": "Measure process load with automatic handling of 'Service Unavailable' plugin for Fastify.",
+      "version": "7.0.0",
+      "homepage": "https://github.com/fastify/under-pressure#readme"
     },
     {
       "name": "fastify-graceful-shutdown",
@@ -43,24 +43,24 @@
       "homepage": "https://github.com/dnlup/fastify-traps#readme"
     },
     {
-      "name": "fastify-rate-limit",
-      "description": "`fastify-rate-limit@5.9.0` has been deprecated. Please use `@fastify/rate-limit@6.0.0` instead.",
-      "version": "5.9.0",
-      "homepage": "https://github.com/fastify/fastify-rate-limit"
+      "name": "@fastify/rate-limit",
+      "description": "A low overhead rate limiter for your routes",
+      "version": "7.3.0",
+      "homepage": "https://github.com/fastify/fastify-rate-limit#readme"
     }
   ],
   "Compatibility": [
     {
-      "name": "middie",
-      "description": "`middie@7.1.0` has been deprecated. Please use `@fastify/middie@8.0.0` instead.",
-      "version": "7.1.0",
-      "homepage": "https://github.com/fastify/middie"
+      "name": "@fastify/middie",
+      "description": "Middleware engine for Fastify",
+      "version": "8.0.0",
+      "homepage": "https://github.com/fastify/middleman#readme"
     },
     {
-      "name": "fastify-express",
-      "description": "`fastify-express@0.4.0` has been deprecated. Please use `@fastify/express@1.0.0` instead.",
-      "version": "0.4.0",
-      "homepage": "https://github.com/fastify/fastify-express"
+      "name": "@fastify/express",
+      "description": "Express compatibility layer for Fastify",
+      "version": "2.0.1",
+      "homepage": "https://github.com/fastify/fastify-express#readme"
     },
     {
       "name": "fastify-normalize-request-reply",
@@ -83,10 +83,10 @@
       "homepage": "https://github.com/fastify/env-schema#readme"
     },
     {
-      "name": "fastify-env",
-      "description": "`fastify-env@2.2.0` has been deprecated. Please use `@fastify/env@3.0.0` instead.",
-      "version": "2.2.0",
-      "homepage": "https://github.com/fastify/fastify-env"
+      "name": "@fastify/env",
+      "description": "Fastify plugin to check environment variables",
+      "version": "4.0.0",
+      "homepage": "https://github.com/fastify/fastify-env#readme"
     },
     {
       "name": "fastify-envalid",
@@ -97,15 +97,15 @@
   ],
   "Essentials": [
     {
-      "name": "fastify-sensible",
-      "description": "`fastify-sensible@3.2.0` has been deprecated. Please use `@fastify/sensible@4.0.0` instead.",
-      "version": "3.2.0",
-      "homepage": "https://github.com/fastify/fastify-sensible"
+      "name": "@fastify/sensible",
+      "description": "Defaults for Fastify that everyone can agree on",
+      "version": "5.1.0",
+      "homepage": "https://github.com/fastify/fastify-sensible#readme"
     },
     {
-      "name": "fastify-static",
-      "description": "`fastify-static@4.7.0` has been deprecated. Please use `@fastify/static@5.0.0` instead.",
-      "version": "4.7.0",
+      "name": "@fastify/static",
+      "description": "Plugin for serving static files as fast as possible.",
+      "version": "6.5.0",
       "homepage": "https://github.com/fastify/fastify-static"
     }
   ],
@@ -131,10 +131,10 @@
   ],
   "Validation": [
     {
-      "name": "fastify-response-validation",
-      "description": "`fastify-response-validation@0.3.0` has been deprecated. Please use `@fastify/response-validation@1.0.0` instead.",
-      "version": "0.3.0",
-      "homepage": "https://github.com/fastify/fastify-response-validation"
+      "name": "@fastify/response-validation",
+      "description": "A simple plugin that enables response validation for Fastify.",
+      "version": "2.1.0",
+      "homepage": "https://github.com/fastify/fastify-response-validation#readme"
     },
     {
       "name": "fastify-no-additional-properties",
@@ -169,28 +169,28 @@
       "homepage": "https://github.com/TakNePoidet/fastify-route-group#readme"
     },
     {
-      "name": "fastify-funky",
-      "description": "`fastify-funky@1.1.0` has been deprecated. Please use `@fastify/funky@2.0.0` instead.",
-      "version": "1.1.0",
+      "name": "@fastify/funky",
+      "description": "Support for fastify routes returning functional structures, such as fp-ts Either, Task, TaskEither or plain javascript parameterless functions",
+      "version": "2.0.0",
       "homepage": "https://github.com/fastify/fastify-funky"
     },
     {
-      "name": "fastify-circuit-breaker",
-      "description": "`fastify-circuit-breaker@1.2.0` has been deprecated. Please use `@fastify/circuit-breaker@2.0.0` instead.",
-      "version": "1.2.0",
-      "homepage": "https://github.com/fastify/fastify-circuit-breaker"
+      "name": "@fastify/circuit-breaker",
+      "description": "A low overhead circuit breaker for your routes",
+      "version": "3.0.0",
+      "homepage": "https://github.com/fastify/fastify-circuit-breaker#readme"
     },
     {
-      "name": "fastify-routes",
-      "description": "`fastify-routes@3.2.0` has been deprecated. Please use `@fastify/routes@4.0.0` instead.",
-      "version": "3.2.0",
-      "homepage": "https://github.com/fastify/fastify-routes"
+      "name": "@fastify/routes",
+      "description": "A plugin for Fastify that provides a map of routes",
+      "version": "5.0.0",
+      "homepage": "https://github.com/fastify/fastify-routes#readme"
     },
     {
-      "name": "fastify-autoload",
-      "description": "`fastify-autoload@3.13.0` has been deprecated. Please use `@fastify/autoload@4.0.0` instead.",
-      "version": "3.13.0",
-      "homepage": "https://github.com/fastify/fastify-autoload"
+      "name": "@fastify/autoload",
+      "description": "Require all plugins in a directory",
+      "version": "5.1.0",
+      "homepage": "https://github.com/fastify/fastify-autoload#readme"
     },
     {
       "name": "fastify-autocrud",
@@ -261,64 +261,64 @@
   ],
   "HTTP": [
     {
-      "name": "fastify-compress",
-      "description": "`fastify-compress@4.1.0` has been deprecated. Please use `@fastify/compress@5.0.0` instead.",
-      "version": "4.1.0",
-      "homepage": "https://github.com/fastify/fastify-compress"
-    },
-    {
-      "name": "fastify-cookie",
-      "description": "`fastify-cookie@5.7.0` has been deprecated. Please use `@fastify/cookie@6.0.0` instead.",
-      "version": "5.7.0",
-      "homepage": "https://github.com/fastify/fastify-cookie"
-    },
-    {
-      "name": "fastify-cors",
-      "description": "`fastify-cors@6.1.0` has been deprecated. Please use `@fastify/cors@7.0.0` instead.",
+      "name": "@fastify/compress",
+      "description": "Fastify compression utils",
       "version": "6.1.0",
-      "homepage": "https://github.com/fastify/fastify-cors"
+      "homepage": "https://github.com/fastify/fastify-compress#readme"
     },
     {
-      "name": "fastify-csrf",
+      "name": "@fastify/cookie",
+      "description": "Plugin for fastify to add support for cookies",
+      "version": "7.3.1",
+      "homepage": "https://github.com/fastify/fastify-cookie#readme"
+    },
+    {
+      "name": "@fastify/cors",
+      "description": "Fastify CORS",
+      "version": "8.0.0",
+      "homepage": "https://github.com/fastify/fastify-cors#readme"
+    },
+    {
+      "name": "@fastify/csrf-protection",
       "description": "A plugin for adding CSRF protection to Fastify.",
-      "version": "3.1.0",
+      "version": "5.1.0",
       "homepage": "https://github.com/fastify/fastify-csrf#readme"
     },
     {
-      "name": "fastify-accepts",
-      "description": "`fastify-accepts@2.3.0` has been deprecated. Please use `@fastify/accepts@3.0.0` instead.",
-      "version": "2.3.0",
-      "homepage": "https://github.com/fastify/fastify-accepts"
+      "name": "@fastify/accepts",
+      "description": "Add accept parser to fastify",
+      "version": "4.0.0",
+      "homepage": "https://github.com/fastify/fastify-accepts#readme"
     },
     {
-      "name": "fastify-accepts-serializer",
-      "description": "`fastify-accepts-serializer@3.3.0` has been deprecated. Please use `@fastify/accepts-serializer@4.0.0` instead.",
-      "version": "3.3.0",
-      "homepage": "https://github.com/fastify/fastify-accepts-serializer"
+      "name": "@fastify/accepts-serializer",
+      "description": "Serializer according to the accept header",
+      "version": "5.0.0",
+      "homepage": "https://github.com/fastify/fastify-accepts-serializer#readme"
     },
     {
-      "name": "fastify-multipart",
-      "description": "`fastify-multipart@5.4.0` has been deprecated. Please use `@fastify/multipart@6.0.0` instead.",
-      "version": "5.4.0",
-      "homepage": "https://github.com/fastify/fastify-multipart"
-    },
-    {
-      "name": "fastify-helmet",
-      "description": "`fastify-helmet@7.1.0` has been deprecated. Please use `@fastify/helmet@8.0.0` instead.",
+      "name": "@fastify/multipart",
+      "description": "Multipart plugin for Fastify",
       "version": "7.1.0",
-      "homepage": "https://github.com/fastify/fastify-helmet"
+      "homepage": "https://github.com/fastify/fastify-multipart#readme"
     },
     {
-      "name": "fastify-http-proxy",
-      "description": "`fastify-http-proxy@6.3.0` has been deprecated. Please use `@fastify/http-proxy@7.0.0` instead.",
-      "version": "6.3.0",
-      "homepage": "https://github.com/fastify/fastify-http-proxy"
+      "name": "@fastify/helmet",
+      "description": "Important security headers for Fastify",
+      "version": "9.1.0",
+      "homepage": "https://github.com/fastify/fastify-helmet#readme"
     },
     {
-      "name": "fastify-formbody",
-      "description": "`fastify-formbody@5.3.0` has been deprecated. Please use `@fastify/formbody@6.0.0` instead.",
-      "version": "5.3.0",
-      "homepage": "https://github.com/fastify/fastify-formbody"
+      "name": "@fastify/http-proxy",
+      "description": "proxy http requests, for Fastify",
+      "version": "8.2.1",
+      "homepage": "https://github.com/fastify/fastify-http-proxy#readme"
+    },
+    {
+      "name": "@fastify/formbody",
+      "description": "A module for Fastify to parse x-www-form-urlencoded bodies",
+      "version": "7.0.1",
+      "homepage": "https://github.com/fastify/fastify-formbody#readme"
     },
     {
       "name": "fastify-raw-body",
@@ -333,10 +333,10 @@
       "homepage": "https://github.com/vanodevium/fastify-qs#readme"
     },
     {
-      "name": "fastify-url-data",
-      "description": "`fastify-url-data@3.1.0` has been deprecated. Please use `@fastify/url-data@4.0.0` instead.",
-      "version": "3.1.0",
-      "homepage": "https://github.com/fastify/fastify-url-data"
+      "name": "@fastify/url-data",
+      "description": "A Fastify plugin to provide access to URI components",
+      "version": "5.1.0",
+      "homepage": "https://github.com/fastify/fastify-url-data#readme"
     },
     {
       "name": "fastify-405",
@@ -424,10 +424,10 @@
       "homepage": "https://github.com/fastify/fastify-vite"
     },
     {
-      "name": "point-of-view",
-      "description": "`point-of-view@6.3.0` has been deprecated. Please use `@fastify/view@7.0.0` instead.",
-      "version": "6.3.0",
-      "homepage": "https://github.com/fastify/point-of-view"
+      "name": "@fastify/view",
+      "description": "Template plugin for Fastify",
+      "version": "7.0.0",
+      "homepage": "https://github.com/fastify/point-of-view#readme"
     },
     {
       "name": "@applicazza/fastify-nextjs",
@@ -436,10 +436,10 @@
       "homepage": "https://github.com/applicazza/fastify-nextjs"
     },
     {
-      "name": "fastify-nextjs",
-      "description": "`fastify-nextjs@7.3.0` has been deprecated. Please use `@fastify/nextjs@8.0.0` instead.",
-      "version": "7.3.0",
-      "homepage": "https://github.com/fastify/fastify-nextjs"
+      "name": "@fastify/nextjs",
+      "description": "React server side rendering support for Fastify with Next",
+      "version": "8.0.2",
+      "homepage": "https://github.com/fastify/fastify-nextjs#readme"
     },
     {
       "name": "fastify-nuxtjs",
@@ -486,10 +486,10 @@
   ],
   "Databases": [
     {
-      "name": "fastify-postgres",
-      "description": "`fastify-postgres@3.7.0` has been deprecated. Please use `@fastify/postgres@4.0.0` instead.",
-      "version": "3.7.0",
-      "homepage": "https://github.com/fastify/fastify-postgres"
+      "name": "@fastify/postgres",
+      "description": "Fastify PostgreSQL connection plugin",
+      "version": "5.0.0",
+      "homepage": "https://github.com/fastify/fastify-postgres#readme"
     },
     {
       "name": "fastify-slonik",
@@ -498,16 +498,16 @@
       "homepage": "https://github.com/spa5k/fastify-slonik"
     },
     {
-      "name": "fastify-leveldb",
-      "description": "`fastify-leveldb@3.2.0` has been deprecated. Please use `@fastify/leveldb@4.0.0` instead.",
-      "version": "3.2.0",
-      "homepage": "https://github.com/fastify/fastify-leveldb"
+      "name": "@fastify/leveldb",
+      "description": "Plugin to share a common LevelDB connection across Fastify.",
+      "version": "5.0.1",
+      "homepage": "https://github.com/fastify/fastify-leveldb#readme"
     },
     {
-      "name": "fastify-mongodb",
-      "description": "`fastify-mongodb@4.2.0` has been deprecated. Please use `@fastify/mongodb@5.0.0` instead.",
-      "version": "4.2.0",
-      "homepage": "https://github.com/fastify/fastify-mongodb"
+      "name": "@fastify/mongodb",
+      "description": "Fastify MongoDB connection plugin",
+      "version": "6.0.1",
+      "homepage": "https://github.com/fastify/fastify-mongodb#readme"
     },
     {
       "name": "fastify-oracle",
@@ -588,11 +588,6 @@
       "homepage": "https://github.com/nbalduzzi/fastify-knexjs#readme"
     },
     {
-      "name": "fastify-sequelize",
-      "description": "Fastity plugin work with Sequelize (adapter for NodeJS -> Sqlite, Mysql, Mssql, Posgres)",
-      "version": "1.0.4"
-    },
-    {
       "name": "sequelize-fastify",
       "description": "a Sequelize plugin for Fastify.",
       "version": "2.0.0",
@@ -601,10 +596,10 @@
   ],
   "Redis": [
     {
-      "name": "fastify-redis",
-      "description": "`fastify-redis@4.4.0` has been deprecated. Please use `@fastify/redis@5.0.0` instead.",
-      "version": "4.4.0",
-      "homepage": "https://github.com/fastify/fastify-redis"
+      "name": "@fastify/redis",
+      "description": "Plugin to share a common Redis connection across Fastify.",
+      "version": "6.0.0",
+      "homepage": "https://github.com/fastify/fastify-redis#readme"
     },
     {
       "name": "fastify-redis-channels",
@@ -627,10 +622,10 @@
   ],
   "Caching": [
     {
-      "name": "fastify-caching",
-      "description": "`fastify-caching@6.3.0` has been deprecated. Please use `@fastify/caching@7.0.0` instead.",
-      "version": "6.3.0",
-      "homepage": "https://github.com/fastify/fastify-caching"
+      "name": "@fastify/caching",
+      "description": "A plugin for Fastify to enable management of cache control headers",
+      "version": "8.0.1",
+      "homepage": "https://github.com/fastify/fastify-caching#readme"
     },
     {
       "name": "fastify-response-caching",
@@ -659,10 +654,10 @@
   ],
   "Authentication": [
     {
-      "name": "fastify-jwt",
-      "description": "`fastify-jwt@4.2.0` has been deprecated. Please use `@fastify/jwt@5.0.0` instead.",
-      "version": "4.2.0",
-      "homepage": "https://github.com/fastify/fastify-jwt"
+      "name": "@fastify/jwt",
+      "description": "JWT utils for Fastify",
+      "version": "6.3.2",
+      "homepage": "https://github.com/fastify/fastify-jwt#readme"
     },
     {
       "name": "fastify-jwt-authz",
@@ -677,22 +672,22 @@
       "homepage": "https://github.com/charlesread/fastify-jwt-webapp#readme"
     },
     {
-      "name": "fastify-oauth2",
-      "description": "`fastify-oauth2@4.6.0` has been deprecated. Please use `@fastify/oauth2@5.0.0` instead.",
-      "version": "4.6.0",
-      "homepage": "https://github.com/fastify/fastify-oauth2"
+      "name": "@fastify/oauth2",
+      "description": "Perform login using oauth2 protocol",
+      "version": "5.1.0",
+      "homepage": "https://github.com/fastify/fastify-oauth2#readme"
     },
     {
-      "name": "fastify-basic-auth",
-      "description": "`fastify-basic-auth@2.3.0` has been deprecated. Please use `@fastify/basic-auth@3.0.0` instead.",
-      "version": "2.3.0",
-      "homepage": "https://github.com/fastify/fastify-basic-auth"
+      "name": "@fastify/basic-auth",
+      "description": "Fastify basic auth plugin",
+      "version": "4.0.0",
+      "homepage": "https://github.com/fastify/fastify-basic-auth#readme"
     },
     {
-      "name": "fastify-bearer-auth",
-      "description": "`fastify-bearer-auth@6.3.0` has been deprecated. Please use `@fastify/bearer-auth@7.0.0` instead.",
-      "version": "6.3.0",
-      "homepage": "https://github.com/fastify/fastify-bearer-auth"
+      "name": "@fastify/bearer-auth",
+      "description": "An authentication plugin for Fastify",
+      "version": "8.0.1",
+      "homepage": "https://github.com/fastify/fastify-bearer-auth#readme"
     },
     {
       "name": "fastify-totp",
@@ -701,10 +696,10 @@
       "homepage": "https://github.com/heply/fastify-totp#readme"
     },
     {
-      "name": "fastify-auth",
-      "description": "`fastify-auth@1.2.0` has been deprecated. Please use `@fastify/auth@2.0.0` instead.",
-      "version": "1.2.0",
-      "homepage": "https://github.com/fastify/fastify-auth"
+      "name": "@fastify/auth",
+      "description": "Run multiple auth functions in Fastify",
+      "version": "3.0.2",
+      "homepage": "https://github.com/fastify/fastify-auth#readme"
     },
     {
       "name": "fastify-auth0-verify",
@@ -839,10 +834,10 @@
   ],
   "Networking": [
     {
-      "name": "fastify-reply-from",
-      "description": "`fastify-reply-from@6.7.0` has been deprecated. Please use `@fastify/reply-from@7.0.0` instead.",
-      "version": "6.7.0",
-      "homepage": "https://github.com/fastify/fastify-reply-from"
+      "name": "@fastify/reply-from",
+      "description": "forward your HTTP request to another server, for fastify",
+      "version": "8.1.0",
+      "homepage": "https://github.com/fastify/fastify-reply-from#readme"
     },
     {
       "name": "fastify-vhost",
@@ -871,16 +866,16 @@
   ],
   "Session": [
     {
-      "name": "fastify-secure-session",
-      "description": "`fastify-secure-session@3.2.0` has been deprecated. Please use `@fastify/secure-session@4.0.0` instead.",
-      "version": "3.2.0",
-      "homepage": "https://github.com/fastify/fastify-secure-session"
+      "name": "@fastify/secure-session",
+      "description": "Create a secure stateless cookie session for Fastify",
+      "version": "5.2.0",
+      "homepage": "https://github.com/fastify/fastify-secure-session#readme"
     },
     {
-      "name": "fastify-flash",
-      "description": "`fastify-flash@3.1.0` has been deprecated. Please use `@fastify/flash@4.0.0` instead.",
-      "version": "3.1.0",
-      "homepage": "https://github.com/fastify/fastify-flash"
+      "name": "@fastify/flash",
+      "description": "Flash message plugin for fastify.",
+      "version": "5.0.0",
+      "homepage": "http://fastify.io/"
     },
     {
       "name": "@fastify/session",
@@ -899,11 +894,6 @@
       "description": "A good fastify sessions plugin focused on speed.",
       "version": "1.4.4",
       "homepage": "https://github.com/Phara0h/fastify-good-sessions#readme"
-    },
-    {
-      "name": "@mgcrea/fastify-session-sodium-crypto",
-      "description": "Fast sodium-based crypto for fastify-session",
-      "version": "0.8.5"
     },
     {
       "name": "@mgcrea/fastify-session",
@@ -985,10 +975,10 @@
       "homepage": "https://github.com/piscinajs/fastify-piscina#readme"
     },
     {
-      "name": "fastify-schedule",
-      "description": "`fastify-schedule@1.1.0` has been deprecated. Please use `@fastify/schedule@2.0.0` instead.",
-      "version": "1.1.0",
-      "homepage": "https://github.com/fastify/fastify-schedule"
+      "name": "@fastify/schedule",
+      "description": "Fastify plugin for scheduling periodic jobs",
+      "version": "3.0.0",
+      "homepage": "http://github.com/fastify/fastify-schedule"
     },
     {
       "name": "fastify-bree",
@@ -1019,10 +1009,10 @@
       "homepage": "https://github.com/NaturalIntelligence/fastify-xml-body-parser"
     },
     {
-      "name": "fastify-soap-client",
-      "description": "`fastify-soap-client@0.3.0` has been deprecated. Please use `@fastify/soap-client@1.0.0` instead.",
-      "version": "0.3.0",
-      "homepage": "https://github.com/fastify/fastify-soap-client"
+      "name": "@fastify/soap-client",
+      "description": "SOAP client integration",
+      "version": "2.0.0",
+      "homepage": "https://github.com/fastify/fastify-soap-client#readme"
     }
   ],
   "I18N": [
@@ -1079,10 +1069,10 @@
       "homepage": "https://github.com/gj/fastify-ws#readme"
     },
     {
-      "name": "fastify-websocket",
-      "description": "`fastify-websocket@4.3.0` has been deprecated. Please use `@fastify/websocket@5.0.0` instead.",
-      "version": "4.3.0",
-      "homepage": "https://github.com/fastify/fastify-websocket"
+      "name": "@fastify/websocket",
+      "description": "basic websocket support for fastify",
+      "version": "6.0.1",
+      "homepage": "https://github.com/fastify/fastify-websocket#readme"
     },
     {
       "name": "fastify-socket.io",
@@ -1099,10 +1089,10 @@
   ],
   "Dependency Injection": [
     {
-      "name": "fastify-awilix",
-      "description": "`fastify-awilix@1.3.0` has been deprecated. Please use `@fastify/awilix@2.0.0` instead.",
-      "version": "1.3.0",
-      "homepage": "https://github.com/fastify/fastify-awilix"
+      "name": "@fastify/awilix",
+      "description": "Dependency injection support for fastify framework",
+      "version": "3.0.0",
+      "homepage": "http://github.com/fastify/fastify-awilix"
     }
   ],
   "Debugging": [
@@ -1119,10 +1109,10 @@
       "homepage": "https://github.com/jeromemacias/fastify-boom#readme"
     },
     {
-      "name": "fastify-diagnostics-channel",
-      "description": "`fastify-diagnostics-channel@1.1.0` has been deprecated. Please use `@fastify/diagnostics-channel@2.0.0` instead.",
-      "version": "1.1.0",
-      "homepage": "https://github.com/fastify/fastify-diagnostics-channel"
+      "name": "@fastify/diagnostics-channel",
+      "description": "Plugin to deal with diagnostics_channel on Fastify",
+      "version": "4.0.1",
+      "homepage": "https://github.com/fastify/fastify-diagnostics-channel#readme"
     },
     {
       "name": "fastify-sentry",
@@ -1133,10 +1123,10 @@
   ],
   "Documentation": [
     {
-      "name": "fastify-swagger",
-      "description": "`fastify-swagger@5.2.0` has been deprecated. Please use `@fastify/swagger@6.0.0` instead.",
-      "version": "5.2.0",
-      "homepage": "https://github.com/fastify/fastify-swagger"
+      "name": "@fastify/swagger",
+      "description": "Serve Swagger/OpenAPI documentation for Fastify, supporting dynamic generation",
+      "version": "7.4.1",
+      "homepage": "https://github.com/fastify/fastify-swagger#readme"
     },
     {
       "name": "fastify-openapi-docs",
@@ -1225,10 +1215,10 @@
   ],
   "Others": [
     {
-      "name": "fastify-request-context",
-      "description": "`fastify-request-context@2.3.0` has been deprecated. Please use `@fastify/request-context@3.0.0` instead.",
-      "version": "2.3.0",
-      "homepage": "https://github.com/fastify/fastify-request-context"
+      "name": "@fastify/request-context",
+      "description": "Request-scoped storage support, based on Asynchronous Local Storage, with fallback to cls-hooked for older Node versions",
+      "version": "4.0.0",
+      "homepage": "http://github.com/fastify/fastify-request-context"
     },
     {
       "name": "fastify-prettier",

--- a/data.json
+++ b/data.json
@@ -3,64 +3,64 @@
     {
       "name": "fastify-healthcheck",
       "description": "Fastify Plugin to serve responses for health checks",
-      "version": "3.1.0",
+      "version": "4.1.0",
       "homepage": "https://github.com/smartiniOnGitHub/fastify-healthcheck#readme"
     },
     {
       "name": "under-pressure",
-      "description": "Measure process load with automatic handling of 'Service Unavailable' plugin for Fastify.",
-      "version": "5.8.0",
-      "homepage": "https://github.com/fastify/under-pressure#readme"
+      "description": "`under-pressure@6.1.0` has been deprecated. Please use `@fastify/under-pressure@7.0.0` instead.",
+      "version": "6.1.0",
+      "homepage": "https://github.com/fastify/under-pressure"
     },
     {
       "name": "fastify-graceful-shutdown",
       "description": "Gracefully shutdown fastify",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "homepage": "https://github.com/hemerajs/fastify-graceful-shutdown#readme"
     },
     {
       "name": "fastify-custom-healthcheck",
       "description": "Fastify plugin that allows to add custom health checks in your server",
-      "version": "2.0.0",
+      "version": "3.0.1",
       "homepage": "https://github.com/gkampitakis/fastify-custom-healthcheck#readme"
     },
     {
       "name": "@gquittet/graceful-server",
       "description": "Tiny (~5k), dependency-free Node.JS library to make your API more graceful",
-      "version": "2.5.2",
+      "version": "3.0.2",
       "homepage": "https://github.com/gquittet/graceful-server#readme"
     },
     {
       "name": "@mgcrea/fastify-graceful-exit",
       "description": "Graceful exit for your fastify application",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "homepage": "https://github.com/mgcrea/fastify-graceful-exit#readme"
     },
     {
       "name": "@dnlup/fastify-traps",
       "description": "A Fastify plugin to close the server gracefully on SIGINT and SIGTERM signals",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "homepage": "https://github.com/dnlup/fastify-traps#readme"
     },
     {
       "name": "fastify-rate-limit",
-      "description": "A low overhead rate limiter for your routes",
-      "version": "5.7.0",
-      "homepage": "https://github.com/fastify/fastify-rate-limit#readme"
+      "description": "`fastify-rate-limit@5.9.0` has been deprecated. Please use `@fastify/rate-limit@6.0.0` instead.",
+      "version": "5.9.0",
+      "homepage": "https://github.com/fastify/fastify-rate-limit"
     }
   ],
   "Compatibility": [
     {
       "name": "middie",
-      "description": "Middleware engine for Fastify",
-      "version": "6.0.0",
-      "homepage": "https://github.com/fastify/middleman#readme"
+      "description": "`middie@7.1.0` has been deprecated. Please use `@fastify/middie@8.0.0` instead.",
+      "version": "7.1.0",
+      "homepage": "https://github.com/fastify/middie"
     },
     {
       "name": "fastify-express",
-      "description": "Express compatibility layer for Fastify",
-      "version": "0.3.3",
-      "homepage": "https://github.com/fastify/fastify-express#readme"
+      "description": "`fastify-express@0.4.0` has been deprecated. Please use `@fastify/express@1.0.0` instead.",
+      "version": "0.4.0",
+      "homepage": "https://github.com/fastify/fastify-express"
     },
     {
       "name": "fastify-normalize-request-reply",
@@ -79,14 +79,14 @@
     {
       "name": "env-schema",
       "description": "Validate your env variable using Ajv and dotenv",
-      "version": "3.5.2",
+      "version": "5.0.0",
       "homepage": "https://github.com/fastify/env-schema#readme"
     },
     {
       "name": "fastify-env",
-      "description": "Fastify plugin to check environment variables",
-      "version": "2.1.1",
-      "homepage": "https://github.com/fastify/fastify-env#readme"
+      "description": "`fastify-env@2.2.0` has been deprecated. Please use `@fastify/env@3.0.0` instead.",
+      "version": "2.2.0",
+      "homepage": "https://github.com/fastify/fastify-env"
     },
     {
       "name": "fastify-envalid",
@@ -98,14 +98,14 @@
   "Essentials": [
     {
       "name": "fastify-sensible",
-      "description": "Defaults for Fastify that everyone can agree on",
-      "version": "3.1.2",
-      "homepage": "https://github.com/fastify/fastify-sensible#readme"
+      "description": "`fastify-sensible@3.2.0` has been deprecated. Please use `@fastify/sensible@4.0.0` instead.",
+      "version": "3.2.0",
+      "homepage": "https://github.com/fastify/fastify-sensible"
     },
     {
       "name": "fastify-static",
-      "description": "Plugin for serving static files as fast as possible.",
-      "version": "4.5.0",
+      "description": "`fastify-static@4.7.0` has been deprecated. Please use `@fastify/static@5.0.0` instead.",
+      "version": "4.7.0",
       "homepage": "https://github.com/fastify/fastify-static"
     }
   ],
@@ -113,39 +113,39 @@
     {
       "name": "@coobaha/typed-fastify",
       "description": "opinionated types for fastify",
-      "version": "0.6.0",
+      "version": "1.0.0-rc.1",
       "homepage": "https://github.com/Coobaha/typed-fastify"
     },
     {
       "name": "fastify-decorators",
       "description": "Framework aimed to provide useful TypeScript decorators to implement controllers, services and request handlers, built with Fastify.",
-      "version": "3.10.0",
+      "version": "3.13.1",
       "homepage": "https://github.com/L2jLiga/fastify-decorators#readme"
     },
     {
       "name": "fastify-schema-to-typescript",
       "description": "Convert json schema for Fastify to typescript interface",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "homepage": "https://github.com/thomasthiebaud/fastify-schema-to-typescript#readme"
     }
   ],
   "Validation": [
     {
       "name": "fastify-response-validation",
-      "description": "A simple plugin that enables response validation for Fastify.",
-      "version": "0.2.0",
-      "homepage": "https://github.com/fastify/fastify-response-validation#readme"
+      "description": "`fastify-response-validation@0.3.0` has been deprecated. Please use `@fastify/response-validation@1.0.0` instead.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/fastify/fastify-response-validation"
     },
     {
       "name": "fastify-no-additional-properties",
       "description": "Add additionalProperties: false by default to your JSON Schemas",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "homepage": "https://github.com/greguz/fastify-no-additional-properties#readme"
     },
     {
       "name": "fastify-schema-constraint",
       "description": "Choose the right JSON schema to apply to your routes based on your constraints",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/Eomm/fastify-schema-constraint#readme"
     },
     {
@@ -170,27 +170,27 @@
     },
     {
       "name": "fastify-funky",
-      "description": "Support for fastify routes returning functional structures, such as fp-ts Either, Task, TaskEither or plain javascript parameterless functions",
-      "version": "1.0.3",
+      "description": "`fastify-funky@1.1.0` has been deprecated. Please use `@fastify/funky@2.0.0` instead.",
+      "version": "1.1.0",
       "homepage": "https://github.com/fastify/fastify-funky"
     },
     {
       "name": "fastify-circuit-breaker",
-      "description": "A low overhead circuit breaker for your routes",
-      "version": "1.1.0",
-      "homepage": "https://github.com/fastify/fastify-circuit-breaker#readme"
+      "description": "`fastify-circuit-breaker@1.2.0` has been deprecated. Please use `@fastify/circuit-breaker@2.0.0` instead.",
+      "version": "1.2.0",
+      "homepage": "https://github.com/fastify/fastify-circuit-breaker"
     },
     {
       "name": "fastify-routes",
-      "description": "A plugin for Fastify that provides a map of routes",
-      "version": "3.1.0",
-      "homepage": "https://github.com/fastify/fastify-routes#readme"
+      "description": "`fastify-routes@3.2.0` has been deprecated. Please use `@fastify/routes@4.0.0` instead.",
+      "version": "3.2.0",
+      "homepage": "https://github.com/fastify/fastify-routes"
     },
     {
       "name": "fastify-autoload",
-      "description": "Require all plugins in a directory",
-      "version": "3.10.0",
-      "homepage": "https://github.com/fastify/fastify-autoload#readme"
+      "description": "`fastify-autoload@3.13.0` has been deprecated. Please use `@fastify/autoload@4.0.0` instead.",
+      "version": "3.13.0",
+      "homepage": "https://github.com/fastify/fastify-autoload"
     },
     {
       "name": "fastify-autocrud",
@@ -201,19 +201,19 @@
     {
       "name": "fastify-autoroutes",
       "description": "Map directory structure to routes",
-      "version": "2.0.0",
+      "version": "2.1.5",
       "homepage": "https://github.com/GiovanniCardamone/fastify-autoroutes#readme"
     },
     {
       "name": "fastify-print-routes",
       "description": "A simple plugin for Fastify prints all available routes.",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "homepage": "https://sw.cowtech.it/fastify-print-routes"
     },
     {
       "name": "fastify-now",
       "description": "Fastify Now - file based routing for fastify",
-      "version": "2.5.2",
+      "version": "3.0.0",
       "homepage": "https://github.com/yonathan06/fastify-now#readme"
     },
     {
@@ -231,19 +231,19 @@
     {
       "name": "oas-fastify",
       "description": "OAS 3.x to Fastify routes automation",
-      "version": "2.0.0",
-      "homepage": "https://github.com/ahmadnassri/oas-fastify"
+      "version": "3.0.0",
+      "homepage": "https://github.com/ahmadnassri/node-oas-fastify"
     },
     {
       "name": "openapi-validator-middleware",
       "description": "Fast input validation middleware using OpenAPI 2.0 (formerly Swagger) and 3.0 definitions file and ajv",
-      "version": "3.2.4",
+      "version": "3.2.6",
       "homepage": "https://github.com/PayU/openapi-validator-middleware"
     },
     {
       "name": "fastify-file-routes",
       "description": "A Fastify plugin that provides a file system routes, based on the way Next.JS file system routing works, including all possible features.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "homepage": "https://github.com/spa5k/fastify-file-routes#readme"
     },
     {
@@ -262,21 +262,21 @@
   "HTTP": [
     {
       "name": "fastify-compress",
-      "description": "Fastify compression utils",
-      "version": "4.0.1",
-      "homepage": "https://github.com/fastify/fastify-compress#readme"
+      "description": "`fastify-compress@4.1.0` has been deprecated. Please use `@fastify/compress@5.0.0` instead.",
+      "version": "4.1.0",
+      "homepage": "https://github.com/fastify/fastify-compress"
     },
     {
       "name": "fastify-cookie",
-      "description": "Plugin for fastify to add support for cookies",
-      "version": "5.5.0",
-      "homepage": "https://github.com/fastify/fastify-cookie#readme"
+      "description": "`fastify-cookie@5.7.0` has been deprecated. Please use `@fastify/cookie@6.0.0` instead.",
+      "version": "5.7.0",
+      "homepage": "https://github.com/fastify/fastify-cookie"
     },
     {
       "name": "fastify-cors",
-      "description": "Fastify CORS",
-      "version": "6.0.2",
-      "homepage": "https://github.com/fastify/fastify-cors#readme"
+      "description": "`fastify-cors@6.1.0` has been deprecated. Please use `@fastify/cors@7.0.0` instead.",
+      "version": "6.1.0",
+      "homepage": "https://github.com/fastify/fastify-cors"
     },
     {
       "name": "fastify-csrf",
@@ -286,62 +286,62 @@
     },
     {
       "name": "fastify-accepts",
-      "description": "Add accept parser to fastify",
-      "version": "2.1.0",
-      "homepage": "https://github.com/fastify/fastify-accepts#readme"
+      "description": "`fastify-accepts@2.3.0` has been deprecated. Please use `@fastify/accepts@3.0.0` instead.",
+      "version": "2.3.0",
+      "homepage": "https://github.com/fastify/fastify-accepts"
     },
     {
       "name": "fastify-accepts-serializer",
-      "description": "Serializer according to the accept header",
-      "version": "3.2.0",
-      "homepage": "https://github.com/fastify/fastify-accepts-serializer#readme"
+      "description": "`fastify-accepts-serializer@3.3.0` has been deprecated. Please use `@fastify/accepts-serializer@4.0.0` instead.",
+      "version": "3.3.0",
+      "homepage": "https://github.com/fastify/fastify-accepts-serializer"
     },
     {
       "name": "fastify-multipart",
-      "description": "Multipart plugin for Fastify",
-      "version": "5.3.0",
-      "homepage": "https://github.com/fastify/fastify-multipart#readme"
+      "description": "`fastify-multipart@5.4.0` has been deprecated. Please use `@fastify/multipart@6.0.0` instead.",
+      "version": "5.4.0",
+      "homepage": "https://github.com/fastify/fastify-multipart"
     },
     {
       "name": "fastify-helmet",
-      "description": "Important security headers for Fastify",
-      "version": "7.0.1",
-      "homepage": "https://github.com/fastify/fastify-helmet#readme"
+      "description": "`fastify-helmet@7.1.0` has been deprecated. Please use `@fastify/helmet@8.0.0` instead.",
+      "version": "7.1.0",
+      "homepage": "https://github.com/fastify/fastify-helmet"
     },
     {
       "name": "fastify-http-proxy",
-      "description": "proxy http requests, for Fastify",
-      "version": "6.2.1",
-      "homepage": "https://github.com/fastify/fastify-http-proxy#readme"
+      "description": "`fastify-http-proxy@6.3.0` has been deprecated. Please use `@fastify/http-proxy@7.0.0` instead.",
+      "version": "6.3.0",
+      "homepage": "https://github.com/fastify/fastify-http-proxy"
     },
     {
       "name": "fastify-formbody",
-      "description": "A module for Fastify to parse x-www-form-urlencoded bodies",
-      "version": "5.2.0",
-      "homepage": "https://github.com/fastify/fastify-formbody#readme"
+      "description": "`fastify-formbody@5.3.0` has been deprecated. Please use `@fastify/formbody@6.0.0` instead.",
+      "version": "5.3.0",
+      "homepage": "https://github.com/fastify/fastify-formbody"
     },
     {
       "name": "fastify-raw-body",
       "description": "Request raw body",
-      "version": "3.2.0",
+      "version": "4.0.0",
       "homepage": "https://github.com/Eomm/fastify-raw-body#readme"
     },
     {
       "name": "fastify-qs",
       "description": "Fastify plugin for querystring parsing with qs",
-      "version": "3.0.1",
-      "homepage": "https://github.com/webdevium/fastify-qs#readme"
+      "version": "4.0.0",
+      "homepage": "https://github.com/vanodevium/fastify-qs#readme"
     },
     {
       "name": "fastify-url-data",
-      "description": "A Fastify plugin to provide access to URI components",
-      "version": "3.0.3",
-      "homepage": "https://github.com/fastify/fastify-url-data#readme"
+      "description": "`fastify-url-data@3.1.0` has been deprecated. Please use `@fastify/url-data@4.0.0` instead.",
+      "version": "3.1.0",
+      "homepage": "https://github.com/fastify/fastify-url-data"
     },
     {
       "name": "fastify-405",
       "description": "Add 405 HTTP status to your routes",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/Eomm/fastify-405#readme"
     },
     {
@@ -359,7 +359,7 @@
     {
       "name": "fastify-http-errors-enhanced",
       "description": "A error handling plugin for Fastify that uses enhanced HTTP errors.",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "homepage": "https://sw.cowtech.it/fastify-http-errors-enhanced"
     },
     {
@@ -371,13 +371,13 @@
     {
       "name": "fastify-multer",
       "description": "Fastify plugin for handling `multipart/form-data`.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "homepage": "https://github.com/fox1t/fastify-multer#readme"
     },
     {
       "name": "fastify-method-override",
       "description": "plugin for fastify override http verbs",
-      "version": "1.5.6",
+      "version": "1.5.9",
       "homepage": "https://github.com/corsicanec82/fastify-method-override.git#readme"
     },
     {
@@ -406,28 +406,28 @@
     {
       "name": "fastify-formidable",
       "description": "[![Continuous Integration](https://github.com/climba03003/fastify-formidable/actions/workflows/ci.yml/badge.svg)](https://github.com/climba03003/fastify-formidable/actions/workflows/ci.yml) [![Package Manager CI](https://github.com/climba03003/fastify-for",
-      "version": "1.1.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/climba03003/fastify-formidable#readme"
     },
     {
       "name": "fastify-file-upload",
       "description": "file upload plugin for Fastify",
-      "version": "3.0.1",
+      "version": "4.0.0",
       "homepage": "https://github.com/huangang/fastify-file-upload#readme"
     }
   ],
   "Frontend": [
     {
       "name": "fastify-vite",
-      "description": "Fastify plugin to serve Vite SSR applications.",
-      "version": "2.3.1",
-      "homepage": "https://github.com/terixjs/fastify-vite"
+      "description": "Fastify plugin for server-side rendering (SSR) applications based on Vite.",
+      "version": "3.0.0-beta.24",
+      "homepage": "https://github.com/fastify/fastify-vite"
     },
     {
       "name": "point-of-view",
-      "description": "Template plugin for Fastify",
-      "version": "5.1.0",
-      "homepage": "https://github.com/fastify/point-of-view#readme"
+      "description": "`point-of-view@6.3.0` has been deprecated. Please use `@fastify/view@7.0.0` instead.",
+      "version": "6.3.0",
+      "homepage": "https://github.com/fastify/point-of-view"
     },
     {
       "name": "@applicazza/fastify-nextjs",
@@ -437,9 +437,9 @@
     },
     {
       "name": "fastify-nextjs",
-      "description": "React server side rendering support for Fastify with Next",
-      "version": "7.2.0",
-      "homepage": "https://github.com/fastify/fastify-nextjs#readme"
+      "description": "`fastify-nextjs@7.3.0` has been deprecated. Please use `@fastify/nextjs@8.0.0` instead.",
+      "version": "7.3.0",
+      "homepage": "https://github.com/fastify/fastify-nextjs"
     },
     {
       "name": "fastify-nuxtjs",
@@ -487,27 +487,27 @@
   "Databases": [
     {
       "name": "fastify-postgres",
-      "description": "Fastify PostgreSQL connection plugin",
-      "version": "3.6.0",
-      "homepage": "https://github.com/fastify/fastify-postgres#readme"
+      "description": "`fastify-postgres@3.7.0` has been deprecated. Please use `@fastify/postgres@4.0.0` instead.",
+      "version": "3.7.0",
+      "homepage": "https://github.com/fastify/fastify-postgres"
     },
     {
       "name": "fastify-slonik",
       "description": "Fastify Slonik Plugin",
-      "version": "1.4.0",
+      "version": "1.7.0",
       "homepage": "https://github.com/spa5k/fastify-slonik"
     },
     {
       "name": "fastify-leveldb",
-      "description": "Plugin to share a common LevelDB connection across Fastify.",
-      "version": "3.1.1",
-      "homepage": "https://github.com/fastify/fastify-leveldb#readme"
+      "description": "`fastify-leveldb@3.2.0` has been deprecated. Please use `@fastify/leveldb@4.0.0` instead.",
+      "version": "3.2.0",
+      "homepage": "https://github.com/fastify/fastify-leveldb"
     },
     {
       "name": "fastify-mongodb",
-      "description": "Fastify MongoDB connection plugin",
-      "version": "4.1.1",
-      "homepage": "https://github.com/fastify/fastify-mongodb#readme"
+      "description": "`fastify-mongodb@4.2.0` has been deprecated. Please use `@fastify/mongodb@5.0.0` instead.",
+      "version": "4.2.0",
+      "homepage": "https://github.com/fastify/fastify-mongodb"
     },
     {
       "name": "fastify-oracle",
@@ -554,7 +554,7 @@
     {
       "name": "fastify-mongoose-api",
       "description": "API for Mongoose models in one line of code",
-      "version": "1.1.10",
+      "version": "1.2.17",
       "homepage": "https://github.com/jeka-kiselyov/fastify-mongoose-api#readme"
     },
     {
@@ -594,17 +594,17 @@
     },
     {
       "name": "sequelize-fastify",
-      "description": "a simple and lightweight Sequelize plugin for Fastify.",
-      "version": "1.0.9",
+      "description": "a Sequelize plugin for Fastify.",
+      "version": "2.0.0",
       "homepage": "https://github.com/hsynlms/sequelize-fastify#readme"
     }
   ],
   "Redis": [
     {
       "name": "fastify-redis",
-      "description": "Plugin to share a common Redis connection across Fastify.",
-      "version": "4.3.3",
-      "homepage": "https://github.com/fastify/fastify-redis#readme"
+      "description": "`fastify-redis@4.4.0` has been deprecated. Please use `@fastify/redis@5.0.0` instead.",
+      "version": "4.4.0",
+      "homepage": "https://github.com/fastify/fastify-redis"
     },
     {
       "name": "fastify-redis-channels",
@@ -628,9 +628,9 @@
   "Caching": [
     {
       "name": "fastify-caching",
-      "description": "A plugin for Fastify to enable management of cache control headers",
-      "version": "6.2.0",
-      "homepage": "https://github.com/fastify/fastify-caching#readme"
+      "description": "`fastify-caching@6.3.0` has been deprecated. Please use `@fastify/caching@7.0.0` instead.",
+      "version": "6.3.0",
+      "homepage": "https://github.com/fastify/fastify-caching"
     },
     {
       "name": "fastify-response-caching",
@@ -641,13 +641,13 @@
     {
       "name": "async-cache-dedupe",
       "description": "An async deduping cache",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "homepage": "https://github.com/mcollina/async-cache-dedupe#readme"
     },
     {
       "name": "fastify-disablecache",
       "description": "Fastify plugin to disable client-side caching",
-      "version": "2.0.5",
+      "version": "3.0.1",
       "homepage": "https://github.com/Fdawgs/fastify-disablecache"
     },
     {
@@ -660,9 +660,9 @@
   "Authentication": [
     {
       "name": "fastify-jwt",
-      "description": "JWT utils for Fastify",
-      "version": "4.1.3",
-      "homepage": "https://github.com/fastify/fastify-jwt#readme"
+      "description": "`fastify-jwt@4.2.0` has been deprecated. Please use `@fastify/jwt@5.0.0` instead.",
+      "version": "4.2.0",
+      "homepage": "https://github.com/fastify/fastify-jwt"
     },
     {
       "name": "fastify-jwt-authz",
@@ -678,21 +678,21 @@
     },
     {
       "name": "fastify-oauth2",
-      "description": "Perform login using oauth2 protocol",
-      "version": "4.5.0",
-      "homepage": "https://github.com/fastify/fastify-oauth2#readme"
+      "description": "`fastify-oauth2@4.6.0` has been deprecated. Please use `@fastify/oauth2@5.0.0` instead.",
+      "version": "4.6.0",
+      "homepage": "https://github.com/fastify/fastify-oauth2"
     },
     {
       "name": "fastify-basic-auth",
-      "description": "Fastify basic auth plugin",
-      "version": "2.2.0",
-      "homepage": "https://github.com/fastify/fastify-basic-auth#readme"
+      "description": "`fastify-basic-auth@2.3.0` has been deprecated. Please use `@fastify/basic-auth@3.0.0` instead.",
+      "version": "2.3.0",
+      "homepage": "https://github.com/fastify/fastify-basic-auth"
     },
     {
       "name": "fastify-bearer-auth",
-      "description": "An authentication plugin for Fastify",
-      "version": "6.1.0",
-      "homepage": "https://github.com/fastify/fastify-bearer-auth#readme"
+      "description": "`fastify-bearer-auth@6.3.0` has been deprecated. Please use `@fastify/bearer-auth@7.0.0` instead.",
+      "version": "6.3.0",
+      "homepage": "https://github.com/fastify/fastify-bearer-auth"
     },
     {
       "name": "fastify-totp",
@@ -702,20 +702,20 @@
     },
     {
       "name": "fastify-auth",
-      "description": "Run multiple auth functions in Fastify",
-      "version": "1.1.0",
-      "homepage": "https://github.com/fastify/fastify-auth#readme"
+      "description": "`fastify-auth@1.2.0` has been deprecated. Please use `@fastify/auth@2.0.0` instead.",
+      "version": "1.2.0",
+      "homepage": "https://github.com/fastify/fastify-auth"
     },
     {
       "name": "fastify-auth0-verify",
       "description": "Auth0 verification plugin for Fastify",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "homepage": "https://github.com/nearform/fastify-auth0-verify"
     },
     {
       "name": "fastify-esso",
       "description": "Fastify plugin for easy single sign-on",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "homepage": "https://github.com/patrickpissurno/fastify-esso#readme"
     },
     {
@@ -727,13 +727,13 @@
     {
       "name": "fastify-casbin",
       "description": "Plugin for fastify to add generic support for Casbin",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/nearform/fastify-casbin#readme"
     },
     {
       "name": "fastify-casbin-rest",
       "description": "Plugin for fastify to add support for Casbin REST model",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/nearform/fastify-casbin-rest#readme"
     },
     {
@@ -745,7 +745,7 @@
     {
       "name": "fastify-tokenize",
       "description": "A fastify plugin to add Tokenize support through a decorator.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "homepage": "https://github.com/cyyynthia/fastify-tokenize#readme"
     },
     {
@@ -769,7 +769,7 @@
     {
       "name": "fastify-guard",
       "description": "a simple user role and scope checker plugin to protect endpoints for Fastify",
-      "version": "1.3.1",
+      "version": "2.0.0",
       "homepage": "https://github.com/hsynlms/fastify-guard#readme"
     }
   ],
@@ -801,7 +801,7 @@
     {
       "name": "fastify-amqp",
       "description": "Fastify AMQP connection plugin, to use with RabbitMQ",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "homepage": "https://github.com/RafaelGSS/fastify-amqp#readme"
     }
   ],
@@ -815,39 +815,39 @@
     {
       "name": "@mgcrea/fastify-request-logger",
       "description": "Compact request logger plugin for fastify written in TypeScript",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "homepage": "https://github.com/mgcrea/fastify-request-logger#readme"
     },
     {
       "name": "@mgcrea/pino-pretty-compact",
       "description": "Compact request logger plugin for fastify written in TypeScript",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "homepage": "https://github.com/mgcrea/pino-pretty-compact#readme"
     },
     {
       "name": "cls-rtracer",
       "description": "Express & Koa middlewares and Fastify & Hapi plugins for CLS-based request id generation, batteries included",
-      "version": "2.6.0",
+      "version": "2.6.2",
       "homepage": "https://github.com/puzpuzpuz/cls-rtracer"
     },
     {
       "name": "fastify-cloudevents",
       "description": "Fastify Plugin to serialize events in the CloudEvents standard format",
-      "version": "2.6.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/smartiniOnGitHub/fastify-cloudevents#readme"
     }
   ],
   "Networking": [
     {
       "name": "fastify-reply-from",
-      "description": "forward your HTTP request to another server, for fastify",
-      "version": "6.4.2",
-      "homepage": "https://github.com/fastify/fastify-reply-from#readme"
+      "description": "`fastify-reply-from@6.7.0` has been deprecated. Please use `@fastify/reply-from@7.0.0` instead.",
+      "version": "6.7.0",
+      "homepage": "https://github.com/fastify/fastify-reply-from"
     },
     {
       "name": "fastify-vhost",
       "description": "Proxy subdomain http requests to another server",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "homepage": "https://github.com/patrickpissurno/fastify-vhost#readme"
     },
     {
@@ -872,20 +872,20 @@
   "Session": [
     {
       "name": "fastify-secure-session",
-      "description": "Create a secure stateless cookie session for Fastify",
-      "version": "3.0.0",
-      "homepage": "https://github.com/fastify/fastify-secure-session#readme"
+      "description": "`fastify-secure-session@3.2.0` has been deprecated. Please use `@fastify/secure-session@4.0.0` instead.",
+      "version": "3.2.0",
+      "homepage": "https://github.com/fastify/fastify-secure-session"
     },
     {
       "name": "fastify-flash",
-      "description": "Flash message plugin for fastify.",
-      "version": "2.0.2",
-      "homepage": "http://fastify.io/"
+      "description": "`fastify-flash@3.1.0` has been deprecated. Please use `@fastify/flash@4.0.0` instead.",
+      "version": "3.1.0",
+      "homepage": "https://github.com/fastify/fastify-flash"
     },
     {
       "name": "@fastify/session",
       "description": "a session plugin for fastify",
-      "version": "6.4.0",
+      "version": "9.0.0",
       "homepage": "https://github.com/fastify/session#readme"
     },
     {
@@ -908,7 +908,7 @@
     {
       "name": "@mgcrea/fastify-session",
       "description": "Session plugin for fastify written in TypeScript supporting both stateless and stateful sessions",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "homepage": "https://github.com/mgcrea/fastify-session#readme"
     }
   ],
@@ -922,9 +922,9 @@
   ],
   "Search": [
     {
-      "name": "fastify-elasticsearch",
+      "name": "@fastify/elasticsearch",
       "description": "Fastify plugin for elastic search",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/fastify/fastify-elasticsearch#readme"
     }
   ],
@@ -945,7 +945,7 @@
     {
       "name": "fastify-kubernetes",
       "description": "Fastify Kubernetes client plugin",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "homepage": "https://github.com/greguz/fastify-kubernetes#readme"
     }
   ],
@@ -986,14 +986,14 @@
     },
     {
       "name": "fastify-schedule",
-      "description": "Fastify plugin for scheduling periodic jobs",
-      "version": "1.0.0",
-      "homepage": "http://github.com/fastify/fastify-schedule"
+      "description": "`fastify-schedule@1.1.0` has been deprecated. Please use `@fastify/schedule@2.0.0` instead.",
+      "version": "1.1.0",
+      "homepage": "https://github.com/fastify/fastify-schedule"
     },
     {
       "name": "fastify-bree",
       "description": "[![Continuous Integration](https://github.com/climba03003/fastify-bree/actions/workflows/ci.yml/badge.svg)](https://github.com/climba03003/fastify-bree/actions/workflows/ci.yml) [![Package Manager CI](https://github.com/climba03003/fastify-bree/actions/wo",
-      "version": "1.0.4",
+      "version": "2.0.0",
       "homepage": "https://github.com/climba03003/fastify-bree#readme"
     }
   ],
@@ -1007,7 +1007,7 @@
     {
       "name": "fastify-sse-v2",
       "description": "Fastify plugin for sending server side events.",
-      "version": "2.0.6",
+      "version": "2.2.1",
       "homepage": "https://github.com/nodefactoryio/fastify-sse-v2#readme"
     }
   ],
@@ -1015,21 +1015,21 @@
     {
       "name": "fastify-xml-body-parser",
       "description": "Fastify plugin to parse XML payload into JS object",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "homepage": "https://github.com/NaturalIntelligence/fastify-xml-body-parser"
     },
     {
       "name": "fastify-soap-client",
-      "description": "SOAP client integration",
-      "version": "0.2.0",
-      "homepage": "https://github.com/fastify/fastify-soap-client#readme"
+      "description": "`fastify-soap-client@0.3.0` has been deprecated. Please use `@fastify/soap-client@1.0.0` instead.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/fastify/fastify-soap-client"
     }
   ],
   "I18N": [
     {
       "name": "i18next-http-middleware",
       "description": "i18next-http-middleware is a middleware to be used with Node.js web frameworks like express or Fastify and also for Deno.",
-      "version": "3.1.5",
+      "version": "3.2.1",
       "homepage": "https://github.com/i18next/i18next-http-middleware"
     },
     {
@@ -1049,7 +1049,7 @@
     {
       "name": "mercurius",
       "description": "Fastify GraphQL adapter with gateway and subscription support",
-      "version": "9.1.0",
+      "version": "10.1.0",
       "homepage": "https://mercurius.dev"
     },
     {
@@ -1061,13 +1061,13 @@
     {
       "name": "fastify-hasura",
       "description": "A fastify plugin to have fun with Hasura.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "homepage": "https://github.com/ManUtopiK/fastify-hasura#readme"
     },
     {
       "name": "apollo-server-fastify",
       "description": "Production-ready Node.js GraphQL server for Fastify",
-      "version": "3.6.2",
+      "version": "3.10.0",
       "homepage": "https://github.com/apollographql/apollo-server#readme"
     }
   ],
@@ -1080,14 +1080,14 @@
     },
     {
       "name": "fastify-websocket",
-      "description": "basic websocket support for fastify",
-      "version": "4.0.0",
-      "homepage": "https://github.com/fastify/fastify-websocket#readme"
+      "description": "`fastify-websocket@4.3.0` has been deprecated. Please use `@fastify/websocket@5.0.0` instead.",
+      "version": "4.3.0",
+      "homepage": "https://github.com/fastify/fastify-websocket"
     },
     {
       "name": "fastify-socket.io",
       "description": "Fastify plugin for socket.io",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "homepage": "https://github.com/alemagio/fastify-socket.io#readme"
     },
     {
@@ -1100,9 +1100,9 @@
   "Dependency Injection": [
     {
       "name": "fastify-awilix",
-      "description": "Dependency injection support for fastify framework",
-      "version": "1.2.0",
-      "homepage": "http://github.com/fastify/fastify-awilix"
+      "description": "`fastify-awilix@1.3.0` has been deprecated. Please use `@fastify/awilix@2.0.0` instead.",
+      "version": "1.3.0",
+      "homepage": "https://github.com/fastify/fastify-awilix"
     }
   ],
   "Debugging": [
@@ -1120,9 +1120,9 @@
     },
     {
       "name": "fastify-diagnostics-channel",
-      "description": "Plugin to deal with diagnostics_channel on Fastify",
-      "version": "1.0.0",
-      "homepage": "https://github.com/fastify/fastify-diagnostics-channel#readme"
+      "description": "`fastify-diagnostics-channel@1.1.0` has been deprecated. Please use `@fastify/diagnostics-channel@2.0.0` instead.",
+      "version": "1.1.0",
+      "homepage": "https://github.com/fastify/fastify-diagnostics-channel"
     },
     {
       "name": "fastify-sentry",
@@ -1134,20 +1134,20 @@
   "Documentation": [
     {
       "name": "fastify-swagger",
-      "description": "Serve Swagger/OpenAPI documentation for Fastify, supporting dynamic generation",
-      "version": "4.13.1",
-      "homepage": "https://github.com/fastify/fastify-swagger#readme"
+      "description": "`fastify-swagger@5.2.0` has been deprecated. Please use `@fastify/swagger@6.0.0` instead.",
+      "version": "5.2.0",
+      "homepage": "https://github.com/fastify/fastify-swagger"
     },
     {
       "name": "fastify-openapi-docs",
       "description": "A simple plugin for Fastify that generates OpenAPI spec automatically.",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "homepage": "https://sw.cowtech.it/fastify-openapi-docs"
     },
     {
       "name": "fastify-openapi-glue",
       "description": "generate a fastify configuration from an openapi specification",
-      "version": "2.6.6",
+      "version": "4.0.0",
       "homepage": "https://github.com/seriousme/fastify-openapi-glue#readme"
     },
     {
@@ -1173,19 +1173,19 @@
     {
       "name": "fastify-metrics",
       "description": "Prometheus metrics exporter for Fastify",
-      "version": "8.0.0",
+      "version": "9.2.1",
       "homepage": "https://github.com/SkeLLLa/fastify-metrics/blob/master/README.md"
     },
     {
       "name": "nstats",
       "description": "A fast and compact way to get all your network and process stats for your node application.",
-      "version": "4.2.0",
+      "version": "5.0.0",
       "homepage": "https://github.com/Phara0h/nstats"
     },
     {
       "name": "@immobiliarelabs/fastify-metrics",
       "description": "A minimalistic and opinionated Fastify plugin that collects metrics and dispatches them to statsd",
-      "version": "1.0.0",
+      "version": "4.0.1",
       "homepage": "https://github.com/immobiliare/fastify-metrics"
     }
   ],
@@ -1205,7 +1205,7 @@
     {
       "name": "fastify-explorer",
       "description": "Explore your fastify's instances",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "homepage": "https://github.com/Eomm/fastify-explorer#readme"
     }
   ],
@@ -1213,7 +1213,7 @@
     {
       "name": "fastify-mailer",
       "description": "Nodemailer instance initialization and encapsulation in fastify framework",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "homepage": "https://github.com/coopflow/fastify-mailer#readme"
     },
     {
@@ -1226,9 +1226,9 @@
   "Others": [
     {
       "name": "fastify-request-context",
-      "description": "Request-scoped storage support, based on Asynchronous Local Storage, with fallback to cls-hooked for older Node versions",
-      "version": "2.2.0",
-      "homepage": "http://github.com/fastify/fastify-request-context"
+      "description": "`fastify-request-context@2.3.0` has been deprecated. Please use `@fastify/request-context@3.0.0` instead.",
+      "version": "2.3.0",
+      "homepage": "https://github.com/fastify/fastify-request-context"
     },
     {
       "name": "fastify-prettier",
@@ -1239,13 +1239,13 @@
     {
       "name": "fastify-no-icon",
       "description": "A simple Fastify plugin to ignore favicon requests",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "homepage": "https://github.com/jsumners/fastify-no-icon#readme"
     },
     {
       "name": "fastify-favicon",
       "description": "Fastify plugin to serve default favicon requests",
-      "version": "3.1.0",
+      "version": "4.1.0",
       "homepage": "https://github.com/smartiniOnGitHub/fastify-favicon#readme"
     },
     {
@@ -1293,25 +1293,25 @@
     {
       "name": "fastify-twitch-ebs-tools",
       "description": "Fastify plugin providing useful functions for Twitch Extension Backend Services (EBS)",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "homepage": "https://github.com/lukemnet/fastify-twitch-ebs-tools"
     },
     {
       "name": "fastify-stripe",
       "description": "Stripe Node.js Library instance initialization and encapsulation in fastify framework",
-      "version": "2.3.2",
+      "version": "2.4.1",
       "homepage": "https://github.com/coopflow/fastify-stripe#readme"
     },
     {
       "name": "fastify-supabase",
       "description": "Supabase client initialization and encapsulation in fastify framework",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "homepage": "https://github.com/coopflow/fastify-supabase#readme"
     },
     {
       "name": "fastify-secrets-hashicorp",
       "description": "Fastify secrets plugin for HashiCorp Vault",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "homepage": "https://github.com/nearform/fastify-secrets-hashicorp#readme"
     }
   ]

--- a/pacchetto.mjs
+++ b/pacchetto.mjs
@@ -24,4 +24,4 @@ await app.register(FastifyVite, {
 })
 
 await app.vite.commands()
-await app.listen(3000)
+await app.listen({ port: 3000 })

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -1,36 +1,33 @@
 export default {
   Scalability: [
     'fastify-healthcheck',
-    'under-pressure',
+    '@fastify/under-pressure',
     'fastify-graceful-shutdown',
     'fastify-custom-healthcheck',
     '@gquittet/graceful-server',
     '@mgcrea/fastify-graceful-exit',
     '@dnlup/fastify-traps',
-    'fastify-rate-limit'
+    '@fastify/rate-limit'
   ],
   Compatibility: [
-    'middie',
-    'fastify-express',
+    '@fastify/middie',
+    '@fastify/express',
     'fastify-normalize-request-reply'
   ],
   Configuration: [
     'fastify-rob-config',
     'env-schema',
-    'fastify-env',
+    '@fastify/env',
     'fastify-envalid'
   ],
-  Essentials: [
-    'fastify-sensible',
-    'fastify-static'
-  ],
+  Essentials: ['@fastify/sensible', '@fastify/static'],
   TypeScript: [
     '@coobaha/typed-fastify',
     'fastify-decorators',
     'fastify-schema-to-typescript'
   ],
   Validation: [
-    'fastify-response-validation',
+    '@fastify/response-validation',
     'fastify-no-additional-properties',
     'fastify-schema-constraint',
     'fastify-split-validator'
@@ -38,10 +35,10 @@ export default {
   Routing: [
     'fastify-register-routes',
     'fastify-route-group',
-    'fastify-funky',
-    'fastify-circuit-breaker',
-    'fastify-routes',
-    'fastify-autoload',
+    '@fastify/funky',
+    '@fastify/circuit-breaker',
+    '@fastify/routes',
+    '@fastify/autoload',
     'fastify-autocrud',
     'fastify-autoroutes',
     'fastify-print-routes',
@@ -55,19 +52,19 @@ export default {
     '@fastify-resty/core'
   ],
   HTTP: [
-    'fastify-compress',
-    'fastify-cookie',
-    'fastify-cors',
-    'fastify-csrf',
-    'fastify-accepts',
-    'fastify-accepts-serializer',
-    'fastify-multipart',
-    'fastify-helmet',
-    'fastify-http-proxy',
-    'fastify-formbody',
+    '@fastify/compress',
+    '@fastify/cookie',
+    '@fastify/cors',
+    '@fastify/csrf-protection',
+    '@fastify/accepts',
+    '@fastify/accepts-serializer',
+    '@fastify/multipart',
+    '@fastify/helmet',
+    '@fastify/http-proxy',
+    '@fastify/formbody',
     'fastify-raw-body',
     'fastify-qs',
-    'fastify-url-data',
+    '@fastify/url-data',
     'fastify-405',
     'fastify-http-context',
     'fastify-http2https',
@@ -84,9 +81,9 @@ export default {
   ],
   Frontend: [
     'fastify-vite',
-    'point-of-view',
+    '@fastify/view',
     '@applicazza/fastify-nextjs',
-    'fastify-nextjs',
+    '@fastify/nextjs',
     'fastify-nuxtjs',
     'fastify-webpack-hmr',
     'fastify-vue-plugin',
@@ -96,10 +93,10 @@ export default {
     'fastify-babel'
   ],
   Databases: [
-    'fastify-postgres',
+    '@fastify/postgres',
     'fastify-slonik',
-    'fastify-leveldb',
-    'fastify-mongodb',
+    '@fastify/leveldb',
+    '@fastify/mongodb',
     'fastify-oracle',
     'fastify-orientdb',
     'fastify-couchdb',
@@ -113,31 +110,30 @@ export default {
     'fastify-objectionjs',
     'fastify-objectionjs-classes',
     'fastify-knexjs',
-    'fastify-sequelize',
     'sequelize-fastify'
   ],
   Redis: [
-    'fastify-redis',
+    '@fastify/redis',
     'fastify-redis-channels',
     '@mgcrea/fastify-session-redis-store',
     'fastify-lured'
   ],
   Caching: [
-    'fastify-caching',
+    '@fastify/caching',
     'fastify-response-caching',
     'async-cache-dedupe',
     'fastify-disablecache',
     'fastify-peekaboo'
   ],
   Authentication: [
-    'fastify-jwt',
+    '@fastify/jwt',
     'fastify-jwt-authz',
     'fastify-jwt-webapp',
-    'fastify-oauth2',
-    'fastify-basic-auth',
-    'fastify-bearer-auth',
+    '@fastify/oauth2',
+    '@fastify/basic-auth',
+    '@fastify/bearer-auth',
     'fastify-totp',
-    'fastify-auth',
+    '@fastify/auth',
     'fastify-auth0-verify',
     'fastify-esso',
     'fastify-api-key',
@@ -165,55 +161,29 @@ export default {
     'fastify-cloudevents'
   ],
   Networking: [
-    'fastify-reply-from',
+    '@fastify/reply-from',
     'fastify-vhost',
     'k-fastify-gateway',
     'fastify-tls-keygen',
     'fastify-http-client'
   ],
   Session: [
-    'fastify-secure-session',
-    'fastify-flash',
+    '@fastify/secure-session',
+    '@fastify/flash',
     '@fastify/session',
     'fastify-server-session',
     'fastify-good-sessions',
-    '@mgcrea/fastify-session-sodium-crypto',
     '@mgcrea/fastify-session'
   ],
-  Hashing: [
-    'fastify-bcrypt'
-  ],
-  Search: [
-    'fastify-elasticsearch'
-  ],
-  Firebase: [
-    'fastify-firebase-auth'
-  ],
-  Kubernetes: [
-    'arecibo',
-    'fastify-kubernetes'
-  ],
-  AWS: [
-    'fastify-xray',
-    'fastify-dynamodb'
-  ],
-  'Google Cloud': [
-    'fastify-gcloud-trace',
-    'fastify-google-cloud-storage'
-  ],
-  Scheduling: [
-    'fastify-piscina',
-    'fastify-schedule',
-    'fastify-bree'
-  ],
-  SSE: [
-    'fastify-sse',
-    'fastify-sse-v2'
-  ],
-  XML: [
-    'fastify-xml-body-parser',
-    'fastify-soap-client'
-  ],
+  Hashing: ['fastify-bcrypt'],
+  Search: ['@fastify/elasticsearch'],
+  Firebase: ['fastify-firebase-auth'],
+  Kubernetes: ['arecibo', 'fastify-kubernetes'],
+  AWS: ['fastify-xray', 'fastify-dynamodb'],
+  'Google Cloud': ['fastify-gcloud-trace', 'fastify-google-cloud-storage'],
+  Scheduling: ['fastify-piscina', '@fastify/schedule', 'fastify-bree'],
+  SSE: ['fastify-sse', 'fastify-sse-v2'],
+  XML: ['fastify-xml-body-parser', '@fastify/soap-client'],
   I18N: [
     'i18next-http-middleware',
     'fastify-polyglot',
@@ -227,21 +197,19 @@ export default {
   ],
   WebSocket: [
     'fastify-ws',
-    'fastify-websocket',
+    '@fastify/websocket',
     'fastify-socket.io',
     'fastify-wamp-router'
   ],
-  'Dependency Injection': [
-    'fastify-awilix'
-  ],
+  'Dependency Injection': ['@fastify/awilix'],
   Debugging: [
     'fastify-error-page',
     'fastify-boom',
-    'fastify-diagnostics-channel',
+    '@fastify/diagnostics-channel',
     'fastify-sentry'
   ],
   Documentation: [
-    'fastify-swagger',
+    '@fastify/swagger',
     'fastify-openapi-docs',
     'fastify-openapi-glue',
     'fastify-oas'
@@ -253,17 +221,10 @@ export default {
     'nstats',
     '@immobiliarelabs/fastify-metrics'
   ],
-  Testing: [
-    'fastify-mongo-memory',
-    'fastify-knexjs-mock',
-    'fastify-explorer'
-  ],
-  Email: [
-    'fastify-mailer',
-    'fastify-nodemailer'
-  ],
+  Testing: ['fastify-mongo-memory', 'fastify-knexjs-mock', 'fastify-explorer'],
+  Email: ['fastify-mailer', 'fastify-nodemailer'],
   Others: [
-    'fastify-request-context',
+    '@fastify/request-context',
     'fastify-prettier',
     'fastify-no-icon',
     'fastify-favicon',

--- a/views/index.vue
+++ b/views/index.vue
@@ -20,7 +20,7 @@
 							<i-checkbox v-model="plugins[selectedCat][i].checked" />
 						</div>
 						<div class="right">
-							<p class="name"><a :href="plugin.homepage">{{ plugin.name }}</a></p>
+							<p class="name"><a :href="plugin.homepage" target="_blank">{{ plugin.name }}</a></p>
 							<p class="description">{{ plugin.description }}</p>
 						</div>
 					</div>


### PR DESCRIPTION
This PR updates relevant fastify modules, i.e `under-pressure` to `@fastify/under-pressure`.

Important to note that this was quite a manual process as not every `fastify-{x}` can be translated to `@fastify/{x}`.

I've gone through to check they work, and they appear to.

Also, outside the scope of this issue, I also:
- Added `target="_blank"` to the links.
- Updated the README to reflect that when testing locally you will need to run `npm run generate` if you've updated the `plugins.mjs` file.

This will hopefully address issue, [update to @fastify/module-name #6
](https://github.com/fastify/pacchetto/issues/6)